### PR TITLE
Updating quickstart k8s-tew binary version to work out of the box

### DIFF
--- a/docs/_build/html/_sources/quickstart.rst.txt
+++ b/docs/_build/html/_sources/quickstart.rst.txt
@@ -9,7 +9,7 @@ The following snippet will create a cluster on the host computer or in a virtual
     sudo su -
 
     # Download Binary
-    wget https://github.com/darxkies/k8s-tew/releases/download/2.1.0/k8s-tew
+    wget https://github.com/darxkies/k8s-tew/releases/download/2.2.4/k8s-tew
     chmod a+x k8s-tew
 
     # Everything is installed relative to the root directory


### PR DESCRIPTION
Hi there,

Fixing binary version in quickstart. With 2.1.0 version, quickstart didn't handle well with Ubuntu 18.04.

By using 2.2.4, everything's right !